### PR TITLE
Issue #181: Move calls with visible effects outside 'use cdm' blocks

### DIFF
--- a/encrypted-media-respec.html
+++ b/encrypted-media-respec.html
@@ -1617,6 +1617,7 @@
                   </p>
                 </li>
                 <li><p>If the preceding step failed, or if <var>sanitized response</var> is empty, reject <var>promise</var> with a newly created <a def-id="TypeError"></a>.</p></li>
+                <li><p>Let <var>session closed</var> be <code>false</code>.</p>
                 <li><p>Let <var>message</var> be null.</p></li>
                 <li><p>Let <var>message type</var> be null.</p></li>
                 <li><p>Let <var>cdm</var> be the CDM instance represented by this object's <var>cdm instance</var> value.</p></li>
@@ -1673,7 +1674,7 @@
                               </p>
                               <p class="note">A subsequent call to <a def-id="load"></a> with the value of this object's <a def-id="sessionId"></a> would fail because there is no data stored for that session ID.</p>
                             </li>
-                            <li><p>Run the <a def-id="session-closed-algorithm"></a> algorithm on this object.</p></li>
+                            <li><p>Set <var>session closed</var> to <code>true</code>.</p></li>
                           </ol>
                         </dd>
                         <dt>If <var>sanitized response</var> contains a key usage record acknowledgement and <var>sessionType</var> is <a def-id="persistent-usage-record-session"></a></dt>
@@ -1687,7 +1688,7 @@
                               </p>
                               <p class="note">A subsequent call to <a def-id="load"></a> with the value of this object's <a def-id="sessionId"></a> would fail because there is no data stored for that session ID.</p>
                             </li>
-                            <li><p>Run the <a def-id="session-closed-algorithm"></a> algorithm on this object.</p></li>
+                            <li><p>Set <var>session closed</var> to <code>true</code>.</p></li>
                           </ol>
                         </dd>
                         <dt>Otherwise</dt>
@@ -1698,12 +1699,6 @@
                         </dd>
                       </dl>
                     </li>
-                    <li><p>If the set of keys <a href="#known-key">known</a> to the CDM for this object changed or the status of any key(s) changed, run the <a def-id="update-key-statuses-algorithm"></a> algorithm on the <var>session</var>, providing each known key's <a def-id="key-id"></a> along with the appropriate <a>MediaKeyStatus</a>.</p>
-                      <p>Should additional processing be necessary to determine with certainty the status of a key, use <a def-id="status-status-pending"></a>.
-                        Once the additional processing for one or more keys has completed, run the <a def-id="update-key-statuses-algorithm"></a> algorithm again with the actual status(es).
-                      </p>
-                    </li>
-                    <li><p>If the expiration time for the session changed, run the <a def-id="update-expiration-algorithm"></a> algorithm on the <var>session</var>, providing the new expiration time.</p></li>
                     <li><p>If a message needs to be sent to the server, execute the following steps:</p>
                       <ol>
                         <li><p>Let <var>message</var> be that message.</p></li>
@@ -1712,8 +1707,31 @@
                     </li>
                   </ol>
                 </li>
+                <li>
+                  <p>
+                    Follow the steps for the first matching condition below:
+                  </p>
+                  <dl class="switch">
+                    <dt>If <var>session closed</var> is <code>true</code>:</dt>
+                    <dd>
+                      <p>Run the <a def-id="session-closed-algorithm"></a> algorithm on this object.</p>
+                    </dd>
+                    <dt>Otherwise:</dt>
+                    <dd>
+                      <ol>
+                        <li><p>If the set of keys <a href="#known-key">known</a> to the CDM for this object changed or the status of any key(s) changed, run the <a def-id="update-key-statuses-algorithm"></a> algorithm on the <var>session</var>, providing each known key's <a def-id="key-id"></a> along with the appropriate <a>MediaKeyStatus</a>.</p>
+                          <p>Should additional processing be necessary to determine with certainty the status of a key, use <a def-id="status-status-pending"></a>.
+                            Once the additional processing for one or more keys has completed, run the <a def-id="update-key-statuses-algorithm"></a> algorithm again with the actual status(es).
+                          </p>
+                        </li>
+                        <li><p>If the expiration time for the session changed, run the <a def-id="update-expiration-algorithm"></a> algorithm on the <var>session</var>, providing the new expiration time.</p></li>
+
+                        <li><p>If <var>message</var> is not null, run the <a def-id="queue-message-algorithm"></a> algorithm on the <var>session</var>, providing <var>message type</var> and <var>message</var>.</p></li>
+                      </ol>
+                    </dd>
+                  </dl>
+                </li>
                 <li><p>If any of the preceding steps failed, reject <var>promise</var> with <a def-id="new-domexception-named"></a> <a def-id="appropriate-error-name"></a>.</p></li>
-                <li><p>If <var>message</var> is not null, run the <a def-id="queue-message-algorithm"></a> algorithm on the <var>session</var>, providing <var>message type</var> and <var>message</var>.</p></li>
                 <li><p>Resolve <var>promise</var>.</p></li>
               </ol>
             </li>
@@ -1809,18 +1827,19 @@
                         </li>
                       </ol>
                     </li>
-                    <li>
-                      <p>
-                        Run the <a def-id="update-key-statuses-algorithm"></a> algorithm on the <var>session</var>, providing all <a def-id="key-id">key ID(s)</a> in the session along with the <a def-id="status-released"></a> <a>MediaKeyStatus</a> value for each.
-                      </p>
-                    </li>
-
-                    <li><p>Run the <a def-id="update-expiration-algorithm"></a> algorithm on the <var>session</var>, providing <code>NaN</code>.</p></li>
-                    <li><p>Let <var>message type</var> be <a def-id="message-type-license-release"></a>.</p></li>
-                    <li><p>If any of the preceding steps failed, reject <var>promise</var> with <a def-id="new-domexception-named"></a> <a def-id="appropriate-error-name"></a>.</p></li>
-                    <li><p>Run the <a def-id="queue-message-algorithm"></a> algorithm on the <var>session</var>, providing <var>message type</var> and <var>message</var>.</p></li>
                   </ol>
                 </li>
+                <li>
+                  <p>
+                    Run the <a def-id="update-key-statuses-algorithm"></a> algorithm on the <var>session</var>, providing all <a def-id="key-id">key ID(s)</a> in the session along with the <a def-id="status-released"></a> <a>MediaKeyStatus</a> value for each.
+                  </p>
+                </li>
+
+                <li><p>Run the <a def-id="update-expiration-algorithm"></a> algorithm on the <var>session</var>, providing <code>NaN</code>.</p></li>
+                <li><p>Let <var>message type</var> be <a def-id="message-type-license-release"></a>.</p></li>
+                <li><p>If any of the preceding steps failed, reject <var>promise</var> with <a def-id="new-domexception-named"></a> <a def-id="appropriate-error-name"></a>.</p></li>
+                <li><p>Run the <a def-id="queue-message-algorithm"></a> algorithm on the <var>session</var>, providing <var>message type</var> and <var>message</var>.</p></li>
+               
                 <li><p>Resolve <var>promise</var>.</p></li>
               </ol>
             </li>

--- a/index.html
+++ b/index.html
@@ -2235,18 +2235,19 @@ table.simple {
                         </li>
                       </ol>
                     </li>
-                    <li>
-                      <p>
-                        Run the <a href="#update-key-statuses">Update Key Statuses</a> algorithm on the <var>session</var>, providing all <a href="#decryption-key-id">key ID(s)</a> in the session along with the <code><a href="#idl-def-MediaKeyStatus.released">"released"</a></code> <a href="#idl-def-MediaKeyStatus" class="idlType"><code>MediaKeyStatus</code></a> value for each.
-                      </p>
-                    </li>
-
-                    <li><p>Run the <a href="#update-expiration">Update Expiration</a> algorithm on the <var>session</var>, providing <code>NaN</code>.</p></li>
-                    <li><p>Let <var>message type</var> be <code><a href="#idl-def-MediaKeyMessageType.license-release">"license-release"</a></code>.</p></li>
-                    <li><p>If any of the preceding steps failed, reject <var>promise</var> with a new <code><a href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> whose name is the appropriate <a href="#error-names">error name</a>.</p></li>
-                    <li><p>Run the <a href="#queue-message">Queue a "message" Event</a> algorithm on the <var>session</var>, providing <var>message type</var> and <var>message</var>.</p></li>
                   </ol>
                 </li>
+                <li>
+                  <p>
+                    Run the <a href="#update-key-statuses">Update Key Statuses</a> algorithm on the <var>session</var>, providing all <a href="#decryption-key-id">key ID(s)</a> in the session along with the <code><a href="#idl-def-MediaKeyStatus.released">"released"</a></code> <a href="#idl-def-MediaKeyStatus" class="idlType"><code>MediaKeyStatus</code></a> value for each.
+                  </p>
+                </li>
+
+                <li><p>Run the <a href="#update-expiration">Update Expiration</a> algorithm on the <var>session</var>, providing <code>NaN</code>.</p></li>
+                <li><p>Let <var>message type</var> be <code><a href="#idl-def-MediaKeyMessageType.license-release">"license-release"</a></code>.</p></li>
+                <li><p>If any of the preceding steps failed, reject <var>promise</var> with a new <code><a href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> whose name is the appropriate <a href="#error-names">error name</a>.</p></li>
+                <li><p>Run the <a href="#queue-message">Queue a "message" Event</a> algorithm on the <var>session</var>, providing <var>message type</var> and <var>message</var>.</p></li>
+               
                 <li><p>Resolve <var>promise</var>.</p></li>
               </ol>
             </li>
@@ -2277,7 +2278,8 @@ table.simple {
                   </p></div>
                 </li>
                 <li><p>If the preceding step failed, or if <var>sanitized response</var> is empty, reject <var>promise</var> with a newly created <code><a href="#dfn-TypeError">TypeError</a></code>.</p></li>
-                <li><p>Let <var>message</var> be null.</p></li>
+                <li><p>Let <var>session closed</var> be <code>false</code>.</p>
+                </li><li><p>Let <var>message</var> be null.</p></li>
                 <li><p>Let <var>message type</var> be null.</p></li>
                 <li><p>Let <var>cdm</var> be the CDM instance represented by this object's <var>cdm instance</var> value.</p></li>
                 <li><p>Use the <var>cdm</var> to execute the following steps:</p>
@@ -2333,7 +2335,7 @@ table.simple {
                               </p>
                               <div class="note"><div class="note-title marker" aria-level="4" role="heading" id="h-note62"><span>Note</span></div><p class="">A subsequent call to <code><a href="#widl-MediaKeySession-load-Promise-boolean--DOMString-sessionId">load()</a></code> with the value of this object's <code><a href="#widl-MediaKeySession-sessionId">sessionId</a></code> would fail because there is no data stored for that session ID.</p></div>
                             </li>
-                            <li><p>Run the <a href="#session-closed">Session Closed</a> algorithm on this object.</p></li>
+                            <li><p>Set <var>session closed</var> to <code>true</code>.</p></li>
                           </ol>
                         </dd>
                         <dt>If <var>sanitized response</var> contains a key usage record acknowledgement and <var>sessionType</var> is <code><a href="#idl-def-MediaKeySessionType.persistent-usage-record">"persistent-usage-record"</a></code></dt>
@@ -2347,7 +2349,7 @@ table.simple {
                               </p>
                               <div class="note"><div class="note-title marker" aria-level="4" role="heading" id="h-note63"><span>Note</span></div><p class="">A subsequent call to <code><a href="#widl-MediaKeySession-load-Promise-boolean--DOMString-sessionId">load()</a></code> with the value of this object's <code><a href="#widl-MediaKeySession-sessionId">sessionId</a></code> would fail because there is no data stored for that session ID.</p></div>
                             </li>
-                            <li><p>Run the <a href="#session-closed">Session Closed</a> algorithm on this object.</p></li>
+                            <li><p>Set <var>session closed</var> to <code>true</code>.</p></li>
                           </ol>
                         </dd>
                         <dt>Otherwise</dt>
@@ -2358,12 +2360,6 @@ table.simple {
                         </dd>
                       </dl>
                     </li>
-                    <li><p>If the set of keys <a href="#known-key">known</a> to the CDM for this object changed or the status of any key(s) changed, run the <a href="#update-key-statuses">Update Key Statuses</a> algorithm on the <var>session</var>, providing each known key's <a href="#decryption-key-id">key ID</a> along with the appropriate <a href="#idl-def-MediaKeyStatus" class="idlType"><code>MediaKeyStatus</code></a>.</p>
-                      <p>Should additional processing be necessary to determine with certainty the status of a key, use <code><a href="#idl-def-MediaKeyStatus.status-pending">"status-pending"</a></code>.
-                        Once the additional processing for one or more keys has completed, run the <a href="#update-key-statuses">Update Key Statuses</a> algorithm again with the actual status(es).
-                      </p>
-                    </li>
-                    <li><p>If the expiration time for the session changed, run the <a href="#update-expiration">Update Expiration</a> algorithm on the <var>session</var>, providing the new expiration time.</p></li>
                     <li><p>If a message needs to be sent to the server, execute the following steps:</p>
                       <ol>
                         <li><p>Let <var>message</var> be that message.</p></li>
@@ -2372,8 +2368,31 @@ table.simple {
                     </li>
                   </ol>
                 </li>
+                <li>
+                  <p>
+                    Follow the steps for the first matching condition below:
+                  </p>
+                  <dl class="switch">
+                    <dt>If <var>session closed</var> is <code>true</code>:</dt>
+                    <dd>
+                      <p>Run the <a href="#session-closed">Session Closed</a> algorithm on this object.</p>
+                    </dd>
+                    <dt>Otherwise</dt>
+                    <dd>
+                      <ol>
+                        <li><p>If the set of keys <a href="#known-key">known</a> to the CDM for this object changed or the status of any key(s) changed, run the <a href="#update-key-statuses">Update Key Statuses</a> algorithm on the <var>session</var>, providing each known key's <a href="#decryption-key-id">key ID</a> along with the appropriate <a href="#idl-def-MediaKeyStatus" class="idlType"><code>MediaKeyStatus</code></a>.</p>
+                          <p>Should additional processing be necessary to determine with certainty the status of a key, use <code><a href="#idl-def-MediaKeyStatus.status-pending">"status-pending"</a></code>.
+                            Once the additional processing for one or more keys has completed, run the <a href="#update-key-statuses">Update Key Statuses</a> algorithm again with the actual status(es).
+                          </p>
+                        </li>
+                        <li><p>If the expiration time for the session changed, run the <a href="#update-expiration">Update Expiration</a> algorithm on the <var>session</var>, providing the new expiration time.</p></li>
+
+                        <li><p>If <var>message</var> is not null, run the <a href="#queue-message">Queue a "message" Event</a> algorithm on the <var>session</var>, providing <var>message type</var> and <var>message</var>.</p></li>
+                      </ol>
+                    </dd>
+                  </dl>
+                </li>
                 <li><p>If any of the preceding steps failed, reject <var>promise</var> with a new <code><a href="https://heycam.github.io/webidl/#dfn-DOMException">DOMException</a></code> whose name is the appropriate <a href="#error-names">error name</a>.</p></li>
-                <li><p>If <var>message</var> is not null, run the <a href="#queue-message">Queue a "message" Event</a> algorithm on the <var>session</var>, providing <var>message type</var> and <var>message</var>.</p></li>
                 <li><p>Resolve <var>promise</var>.</p></li>
               </ol>
             </li>


### PR DESCRIPTION
In the interest of clarifying which steps involve the CDM, algorithm calls that have visible effects are moved outside of the "Use the CDM to ..." blocks.

[Some purely functional calls, such as "Is persistent session type?" seem harmless and remain.]
